### PR TITLE
In the PS script - quote the password and add /y

### DIFF
--- a/demo-2b/windows-instance.tf
+++ b/demo-2b/windows-instance.tf
@@ -9,7 +9,7 @@ resource "aws_instance" "win-example" {
   key_name = "${aws_key_pair.mykey.key_name}"
   user_data = <<EOF
 <powershell>
-net user ${var.INSTANCE_USERNAME} ${var.INSTANCE_PASSWORD} /add
+net user ${var.INSTANCE_USERNAME} '${var.INSTANCE_PASSWORD}' /add /y
 net localgroup administrators ${var.INSTANCE_USERNAME} /add
 
 winrm quickconfig -q


### PR DESCRIPTION
The PowerShell script inside userdata fails if the password contains spaces, also, if the password is longer than 12 chars (i think it is) Windows will prompt to let you know that it will not work on older versions of Windows.

This simple PR fixes both issues.
