### PR TITLE
change filter to display only linux ami's

### DIFF
--- a/eks-demo/eks-workers.tf
+++ b/eks-demo/eks-workers.tf
@@ -1,7 +1,7 @@
 data "aws_ami" "eks-worker" {
   filter {
     name   = "name"
-    values = ["amazon-eks-node-v*"]
+    values = ["amazon-eks-node-1*"]
   }
 
   most_recent = true


### PR DESCRIPTION
Since AWS also provides windows worker nodes this filter no longer works. Using a filter on amazon-eks-node-1* will only show linux nodes.