### PR TITLE
Remove aws-iam-authenticator in eks-demo

### DIFF
--- a/eks-demo/README.md
+++ b/eks-demo/README.md
@@ -10,13 +10,6 @@ chmod +x kubectl
 sudo mv kubectl /usr/local/bin
 ```
 
-## Download the aws-iam-authenticator
-```
-wget https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.3.0/heptio-authenticator-aws_0.3.0_linux_amd64
-chmod +x heptio-authenticator-aws_0.3.0_linux_amd64
-sudo mv heptio-authenticator-aws_0.3.0_linux_amd64 /usr/local/bin/heptio-authenticator-aws
-```
-
 ## Modify providers.tf
 
 Choose your region. EKS is not available in every region, use the Region Table to check whether your region is supported: https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/


### PR DESCRIPTION
`If you're running the AWS CLI version 1.16.156 or later, then you don't need to install the authenticator. Instead, you can use the aws eks get-token command`

https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html

It is enough to `aws eks --region <region> update-kubeconfig --name terraform-eks-demo` to update the kubectl config, as you have in the readme later