### PR TITLE
Update buildspec.yml for new AWS CLI ECR login

### DIFF
--- a/codepipeline-demo/app/config/buildspec.yml
+++ b/codepipeline-demo/app/config/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - $(aws ecr get-login --no-include-email)
+      - $(aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com)
   build:
     commands:
       - docker build -t $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$CODEBUILD_RESOLVED_SOURCE_VERSION .


### PR DESCRIPTION
Hi Edward,

The ECR login method in this code is deprecated (https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html). 
To login to ECR you need to use what is in the documentation here: https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html
I refactored the login command using the new command in the link above.

Thank you,