### PR TITLE
Demo 12 - Version and Deprecation

### DIFF
--- a/demo-12/rds.tf
+++ b/demo-12/rds.tf
@@ -18,7 +18,7 @@ resource "aws_db_parameter_group" "mariadb-parameters" {
 resource "aws_db_instance" "mariadb" {
   allocated_storage       = 100 # 100 GB of storage, gives us more IOPS than a lower number
   engine                  = "mariadb"
-  engine_version          = "10.4.13"
+  engine_version          = "10.4"
   instance_class          = "db.t2.small" # use micro if you want to use the free tier
   identifier              = "mariadb"
   db_name                 = "mariadb"

--- a/demo-12/rds.tf
+++ b/demo-12/rds.tf
@@ -21,7 +21,7 @@ resource "aws_db_instance" "mariadb" {
   engine_version          = "10.4.13"
   instance_class          = "db.t2.small" # use micro if you want to use the free tier
   identifier              = "mariadb"
-  name                    = "mariadb"
+  db_name                 = "mariadb"
   username                = "root"           # username
   password                = var.RDS_PASSWORD # password
   db_subnet_group_name    = aws_db_subnet_group.mariadb-subnet.name


### PR DESCRIPTION
Changes to fix below issues.

**Error**

```Error: Error creating DB Instance: InvalidParameterCombination: Cannot find version 10.4.13 for mariadb```

Fixed version is no longer available (currently `10.4.21` to `10.4.25`). However [engine_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine_version) supports prefix of the version. So passing `10.4` instead supports current major and minor version and future patch versions.

**Warning**

```
Warning: Argument is deprecated
│ 
│   with aws_db_instance.mariadb,
│   on rds.tf line 24, in resource "aws_db_instance" "mariadb":
│   24:   name                    = "mariadb"
│ 
│ Use db_name instead```

Updating deprecated argument.
