### PR TITLE
update ami filter

### DIFF
--- a/demo-18/instance.tf
+++ b/demo-18/instance.tf
@@ -3,7 +3,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
   }
 
   filter {


### PR DESCRIPTION
There are no ubuntu-trusty-14.04* images anymore in aws, hence updated filter to `bionic-18.04`